### PR TITLE
Prevent crashes for server based environments with 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'fabric-loom' version '0.11-SNAPSHOT'
+  id 'fabric-loom' version '0.12-SNAPSHOT'
   id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,12 +8,12 @@ yarn_mappings=1.19+build.1
 loader_version=0.14.7
 
 # Mod Properties
-mod_version = 1.0.1
+mod_version = 1.0.2
 maven_group = com.quarrymod
 archives_base_name = quarry-reborn-1.19.0
 
 # Dependencies
-fabric_version=0.55.3+1.19
+fabric_version=0.57.0+1.19
 # Can be found on https://github.com/TechReborn/TechReborn/releases
-tr_version=1.19:5.3.0
-rc_version=1.19:5.3.0
+tr_version=1.19:5.3.2
+rc_version=1.19:5.3.2

--- a/src/main/java/net/quarrymod/RegistryManager.java
+++ b/src/main/java/net/quarrymod/RegistryManager.java
@@ -6,6 +6,7 @@ import static reborncore.RebornRegistry.registerItem;
 import java.util.Arrays;
 import net.minecraft.item.Item.Settings;
 import net.minecraft.util.Identifier;
+import net.quarrymod.client.QuarryScreenRegistry;
 import net.quarrymod.events.StackToolTipHandler;
 import net.quarrymod.init.QuarryManagerContent;
 import net.quarrymod.init.QuarryManagerContent.Machine;
@@ -44,6 +45,8 @@ public class RegistryManager {
 
     @SuppressWarnings("MethodCallSideOnly")
     public static void ClientInit() {
+
         StackToolTipHandler.setup();
+        QuarryScreenRegistry.init();
     }
 }

--- a/src/main/java/net/quarrymod/client/QuarryScreenRegistry.java
+++ b/src/main/java/net/quarrymod/client/QuarryScreenRegistry.java
@@ -1,0 +1,18 @@
+package net.quarrymod.client;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.screenhandler.v1.ScreenRegistry;
+import org.jetbrains.annotations.Contract;
+
+@Environment(EnvType.CLIENT)
+public class QuarryScreenRegistry {
+
+    private QuarryScreenRegistry() {
+        // Left empty to hide the original constructor
+    }
+
+    public static void init() {
+        ScreenRegistry.register(GuiType.QUARRY.getType(), GuiType.QUARRY.getGuiFactory());
+    }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,11 +28,11 @@
   "mixins": [
   ],
   "depends": {
-    "fabricloader": ">=0.12.0",
+    "fabricloader": ">=0.14.7",
     "fabric": "*",
     "minecraft": "1.19.x",
     "java": ">=17",
-    "techreborn": ">=5.3.0"
+    "techreborn": ">=5.3.2"
   },
   "suggests": {
     "another-mod": "*"


### PR DESCRIPTION
Remove screen dependencies from the server side mod.
Add new class to handle client side GUIs on 1.19

Update version to use the latest libraries.